### PR TITLE
add support for ADC buttons that pulls down to 0, to class BfButtonManager

### DIFF
--- a/src/BfButtonManager.cpp
+++ b/src/BfButtonManager.cpp
@@ -47,6 +47,12 @@ BfButtonManager& BfButtonManager::setADCResolution(uint16_t resolution) {
   this->_adcResolution = resolution;
   return *this;
 }
+
+BfButtonManager& BfButtonManager::setADCBounds(uint16_t lowerBound, uint16_t upperBound) {
+  this->_adcLowerBound = lowerBound;
+  this->_adcResolution = upperBound;
+  return *this;
+}
     
 BfButtonManager& BfButtonManager::addButton(BfButton* btn, uint16_t minVoltageReading, uint16_t maxVoltageReading) {
   uint8_t _b = btn->getID();
@@ -102,9 +108,9 @@ int8_t BfButtonManager::_readButton() {
   }
   z = _sum / 4;
   
-  if (z >= 100 || z < this->_adcResolution) {
+  if (z >= this->_adcLowerBound || z < this->_adcResolution) {
     for (int8_t _b = 0; _b < this->_buttonCount; _b++) {
-      if (z > this->_btnVoltageLowerBounds[_b] && z < this->_btnVoltageUpperBounds[_b]) {
+      if (z >= this->_btnVoltageLowerBounds[_b] && z <= this->_btnVoltageUpperBounds[_b]) {
         _button = _b;
         break;
       }

--- a/src/BfButtonManager.cpp
+++ b/src/BfButtonManager.cpp
@@ -108,7 +108,7 @@ int8_t BfButtonManager::_readButton() {
   }
   z = _sum / 4;
   
-  if (z >= this->_adcLowerBound || z < this->_adcResolution) {
+  if (z >= this->_adcLowerBound || z <= this->_adcResolution) {
     for (int8_t _b = 0; _b < this->_buttonCount; _b++) {
       if (z >= this->_btnVoltageLowerBounds[_b] && z <= this->_btnVoltageUpperBounds[_b]) {
         _button = _b;

--- a/src/BfButtonManager.cpp
+++ b/src/BfButtonManager.cpp
@@ -82,7 +82,7 @@ void BfButtonManager::loop() {
 uint16_t BfButtonManager::printReading(uint8_t pin) {
   int z;
   z = analogRead(pin);
-  if (z > 100) Serial.println(z);
+  if (z >= this->_adcLowerBound) Serial.println(z);
   return z;
 }
 

--- a/src/BfButtonManager.h
+++ b/src/BfButtonManager.h
@@ -48,7 +48,7 @@ class BfButtonManager {
     BfButtonManager& setADCResolution(uint16_t resolution);
 
     /*
-     * Set the lower & upper bounds for the acceptable voltage range for ADC buttons (upperBound = resolution)
+     * Set the lower & upper bounds to define the acceptable range for ADC buttons (upperBound = resolution)
      * defaults: lowerBound = 50, upperBound = 1024 (4096 for ESP32)
      */
     BfButtonManager& setADCBounds(uint16_t lowerBound, uint16_t upperBound);

--- a/src/BfButtonManager.h
+++ b/src/BfButtonManager.h
@@ -46,6 +46,12 @@ class BfButtonManager {
      * The library will set build-in ADC for Arduino and ESP32 by default.
      */
     BfButtonManager& setADCResolution(uint16_t resolution);
+
+    /*
+     * Set the lower & upper bounds for the acceptable voltage range for ADC buttons (upperBound = resolution)
+     * defaults: lowerBound = 50, upperBound = 1024 (4096 for ESP32)
+     */
+    BfButtonManager& setADCBounds(uint16_t lowerBound, uint16_t upperBound);
     
     /*
      * Add button to button array.
@@ -88,6 +94,8 @@ class BfButtonManager {
     #else
     uint16_t _adcResolution = 1024;
     #endif
+
+    uint16_t _adcLowerBound = 100;
     
     unsigned long _lastLoop = 0;
     uint8_t _loopInterval = 20;


### PR DESCRIPTION
Some shields e.g. the DFR0009 by DFRobot
https://wiki.dfrobot.com/LCD_KeyPad_Shield_For_Arduino_SKU__DFR0009
include buttons that pull down to 0 when pressed.
This change adds support for this type of button.

The current master code allows the upper bound (resolution) to be set, but the lower bound is hard coded as 100.

Added _adcLowerBound to class BfButtonManager, with method to set it (setADCBounds).
_adcLowerBound defaults to 100 (current hard coded value).